### PR TITLE
RankMe Support Issue

### DIFF
--- a/addons/sourcemod/scripting/hextags.sp
+++ b/addons/sourcemod/scripting/hextags.sp
@@ -141,7 +141,7 @@ public void OnAllPluginsLoaded()
 		LogMessage("[HexTags] Found Custom Chat Colors running!\n	Please avoid running it with this plugin!");
 	
 	bMostActive = LibraryExists("mostactive");
-	bRankme = LibraryExists("rankme") && cv_bDisableRankme.BoolValue;
+	bRankme = LibraryExists("rankme") && !cv_bDisableRankme.BoolValue;
 	bWarden = LibraryExists("warden");
 	bMyJBWarden = LibraryExists("myjbwarden");
 	bGangs = LibraryExists("hl_gangs");
@@ -163,7 +163,7 @@ public void OnLibraryAdded(const char[] name)
 	{
 		bMostActive = true;
 	}
-	else if (StrEqual(name, "rankme") && cv_bDisableRankme.BoolValue)
+	else if (StrEqual(name, "rankme") && !cv_bDisableRankme.BoolValue)
 	{
 		bRankme = true;
 	}


### PR DESCRIPTION
Basically for RankMe is present or not conditions had a issue. 

bRankme = LibraryExists("rankme") && cv_bDisableRankme.BoolValue; basically used to send 2 different answers, one is true as 1 and for 2nd conditions from default will send 0 sending bRankMe as false of Rankme Support.

Fix #32 