### PR TITLE
Fixed console spamming

### DIFF
--- a/addons/sourcemod/scripting/hextags.sp
+++ b/addons/sourcemod/scripting/hextags.sp
@@ -2,7 +2,7 @@
  * HexTags Plugin.
  * by: Hexah
  * https://github.com/Hexer10/HexTags
- * 
+ *
  * Copyright (C) 2017-2020 Mattia (Hexah|Hexer10|Papero)
  *
  * This file is part of the HexTags SourceMod Plugin.
@@ -10,7 +10,7 @@
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, version 3.0, as published by the
  * Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
@@ -42,7 +42,7 @@
 #define REQUIRE_PLUGIN
 
 #define PLUGIN_AUTHOR         "Hexah"
-#define PLUGIN_VERSION        "<TAG>"
+#define PLUGIN_VERSION        "2.02"
 
 #pragma semicolon 1
 #pragma newdecls required
@@ -98,24 +98,24 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 {
 	//API
 	RegPluginLibrary("hextags");
-	
+
 	CreateNative("HexTags_GetClientTag", Native_GetClientTag);
 	CreateNative("HexTags_SetClientTag", Native_SetClientTag);
 	CreateNative("HexTags_ResetClientTag", Native_ResetClientTags);
 	CreateNative("HexTags_AddCustomSelector", Native_AddCustomSelector);
 	CreateNative("HexTags_RemoveCustomSelector", Native_RemoveCustomSelector);
-	
+
 	fTagsUpdated = new GlobalForward("HexTags_OnTagsUpdated", ET_Ignore, Param_Cell);
-	
+
 	fMessageProcess = new GlobalForward("HexTags_OnMessageProcess", ET_Single, Param_Cell, Param_String, Param_String);
 	fMessageProcessed = new GlobalForward("HexTags_OnMessageProcessed", ET_Ignore, Param_Cell, Param_String, Param_String);
 	fMessagePreProcess = new GlobalForward("HexTags_OnMessagePreProcess", ET_Single, Param_Cell, Param_String, Param_String);
-	
+
 	pfCustomSelector = new PrivateForward(ET_Single, Param_Cell, Param_String);
-	
+
 	EngineVersion engine = GetEngineVersion();
 	bCSGO = (engine == Engine_CSGO || engine == Engine_CSS);
-	
+
 	//LateLoad
 	bLate = late;
 	return APLRes_Success;
@@ -129,22 +129,22 @@ public void OnPluginStart()
 	cv_sDefaultGang = CreateConVar("sm_hextags_nogang", "", "Text to use if user has no tag - needs hl_gangs.");
 	cv_bParseRoundEnd = CreateConVar("sm_hextags_roundend", "0", "If 1 the tags will be reloaded even on round end - Suggested to be used with plugins like mostactive or rankme.");
 	cv_bEnableTagsList = CreateConVar("sm_hextags_enable_tagslist", "0", "Set to 1 to enable the sm_tagslist command.");
-	
+
 	AutoExecConfig();
-	
+
 	//Reg Cmds
 	RegAdminCmd("sm_reloadtags", Cmd_ReloadTags, ADMFLAG_GENERIC, "Reload HexTags plugin config");
 	RegAdminCmd("sm_toggletags", Cmd_ToggleTags, ADMFLAG_GENERIC, "Toggle the visibility of your tags");
 	RegConsoleCmd("sm_tagslist", Cmd_TagsList, "Select your tag!");
 	RegConsoleCmd("sm_getteam", Cmd_GetTeam, "Get current team name");
-	
+
 	//Event hooks
 	if (!HookEventEx("round_end", Event_RoundEnd))
 	LogError("Failed to hook \"round_end\", \"sm_hextags_roundend\" won't produce any effect.");
-	
+
 	hVibilityCookie = RegClientCookie("HexTags_Visibility", "Show or hide the tags.", CookieAccess_Private);
 	hSelTagCookie = RegClientCookie("HexTags_SelectedTag", "Selected Tag", CookieAccess_Private);
-	
+
 #if defined DEBUG
 	RegConsoleCmd("sm_gettagvars", Cmd_GetVars);
 	RegConsoleCmd("sm_firesel", Cmd_FireSel);
@@ -152,29 +152,29 @@ public void OnPluginStart()
 }
 
 public void OnAllPluginsLoaded()
-{	
+{
 	Debug_Print("Called OnAllPlugins!");
-	
+
 	if (FindPluginByFile("custom-chatcolors-cp.smx") || LibraryExists("ccc"))
 	LogMessage("[HexTags] Found Custom Chat Colors running!\n	Please avoid running it with this plugin!");
-	
+
 	bMostActive = LibraryExists("mostactive");
 	bRankme = LibraryExists("rankme");
 	bWarden = LibraryExists("warden");
 	bMyJBWarden = LibraryExists("myjbwarden");
 	bGangs = LibraryExists("hl_gangs");
 	bSteamWorks = LibraryExists("SteamWorks");
-	
+
 	LoadKv();
-	if (bLate) for (int i = 1; i <= MaxClients; i++)if (IsClientInGame(i)) 
+	if (bLate) for (int i = 1; i <= MaxClients; i++)if (IsClientInGame(i))
 	{
 		OnClientPutInServer(i);
 		if (!AreClientCookiesCached(i))
 			OnClientCookiesCached(i);
-		
+
 		OnClientPostAdminCheck(i);
 	}
-	
+
 	//Timers
 	if (bCSGO)
 	CreateTimer(5.0, Timer_ForceTag, _, TIMER_REPEAT);
@@ -249,32 +249,32 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 {
 	if (bHideTag[client])
 	return Plugin_Continue;
-	
+
 	char sKey[64];
-	
+
 	if (!bCSGO || !kv.GetSectionName(sKey, sizeof(sKey)))
 	return Plugin_Continue;
-	
+
 #if defined DEBUG
 	char sKV[256];
 	kv.ExportToString(sKV, sizeof(sKV));
 	Debug_Print("Called ClientCmdKv: %s\n%s\n", sKey, sKV);
 #endif
-	
+
 	if(StrEqual(sKey, "ClanTagChanged"))
 	{
 		kv.GetString("tag", sUserTag[client], sizeof(sUserTag[]));
 		LoadTags(client);
-		
+
 		if(selectedTags[client].ScoreTag[0] == '\0')
 		return Plugin_Continue;
-		
+
 		kv.SetString("tag", selectedTags[client].ScoreTag);
 		Debug_Print("[ClanTagChanged] Setted tag: %s ", selectedTags[client].ScoreTag);
 		return Plugin_Changed;
 	}
-	
-	return Plugin_Continue; 
+
+	return Plugin_Continue;
 }
 
 public void OnClientDisconnect(int client)
@@ -295,9 +295,9 @@ public void warden_OnWardenRemoved(int client)
 {
 	if (bCSGO)
 	CS_SetClientClanTag(client, sUserTag[client]);
-	
+
 	RequestFrame(Frame_LoadTag, client);
-	
+
 }
 
 public void warden_OnDeputyCreated(int client)
@@ -309,7 +309,7 @@ public void warden_OnDeputyRemoved(int client)
 {
 	if (bCSGO)
 	CS_SetClientClanTag(client, sUserTag[client]);
-	
+
 	RequestFrame(Frame_LoadTag, client);
 }
 
@@ -318,7 +318,7 @@ public Action Cmd_ReloadTags(int client, int args)
 {
 	LoadKv();
 	for (int i = 1; i <= MaxClients; i++)if (IsClientInGame(i))LoadTags(i);
-	
+
 	ReplyToCommand(client, "[SM] Tags succesfully reloaded!");
 	return Plugin_Handled;
 }
@@ -330,14 +330,14 @@ public Action Cmd_ToggleTags(int client, int args)
 		bHideTag[client] = false;
 		LoadTags(client);
 		ReplyToCommand(client, "[SM] Your tags are visible again.");
-	} 
+	}
 	else
 	{
 		bHideTag[client] = true;
 		CS_SetClientClanTag(client, sUserTag[client]);
 		ReplyToCommand(client, "[SM] Your tags are no longer visible.");
 	}
-	
+
 	SetClientCookie(client, hVibilityCookie, bHideTag[client] ? "0" : "1");
 }
 
@@ -348,25 +348,25 @@ public Action Cmd_TagsList(int client, int args)
 		ReplyToCommand(client, "[SM] In-game only command.");
 		return Plugin_Handled;
 	}
-	
+
 	if (userTags[client] == null)
 	{
 		ReplyToCommand(client, "[SM] Tags not yet loaded.");
 		return Plugin_Handled;
 	}
-	
-	if (!cv_bEnableTagsList.BoolValue) 
+
+	if (!cv_bEnableTagsList.BoolValue)
 	{
 		ReplyToCommand(client, "[SM] This feature is not enabled.");
 		return Plugin_Handled;
 	}
-	
+
 	if (userTags[client].Length == 0)
 	{
 		ReplyToCommand(client, "[SM] No tags available.");
 		return Plugin_Handled;
 	}
-	
+
 	Menu menu = new Menu(Handler_TagsMenu);
 	menu.SetTitle("Choose your tag:");
 	static char sIndex[16];
@@ -398,13 +398,13 @@ public int Handler_TagsMenu(Menu menu, MenuAction action, int param1, int param2
 			CS_SetClientClanTag(param1, selectedTags[param1].ScoreTag);
 		}
 		iSelTagId[param1] = selectedTags[param1].SectionId;
-		
+
 		static char sValue[32];
 		IntToString(iSelTagId[param1], sValue, sizeof(sValue));
 		SetClientCookie(param1, hSelTagCookie, sValue);
 		PrintToChat(param1, "[SM] Setted %s tags", selectedTags[param1].TagName);
 	}
-	
+
 }
 
 public Action Cmd_GetTeam(int client, int args)
@@ -414,7 +414,7 @@ public Action Cmd_GetTeam(int client, int args)
 		ReplyToCommand(client, "[SM] In-game only command.");
 		return Plugin_Handled;
 	}
-	
+
 	char sTeam[32];
 	GetTeamName(GetClientTeam(client), sTeam, sizeof(sTeam));
 	ReplyToCommand(client, "[SM] Current team name: %s", sTeam);
@@ -435,7 +435,7 @@ public Action Cmd_FireSel(int client, int args)
 {
 	int count = pfCustomSelector.FunctionCount;
 	int res;
-	
+
 	Call_StartForward(pfCustomSelector);
 	Call_PushCell(client);
 	Call_PushString("thistoggle");
@@ -461,9 +461,9 @@ public void OnClientCookiesCached(int client)
 {
 	static char sValue[32];
 	GetClientCookie(client, hVibilityCookie, sValue, sizeof(sValue));
-	
+
 	bHideTag[client] = sValue[0] == '\0' ? false : !StringToInt(sValue);
-		
+
 	GetClientCookie(client, hSelTagCookie, sValue, sizeof(sValue));
 	if (sValue[0] == '\0')
 	{
@@ -475,7 +475,7 @@ public void OnClientCookiesCached(int client)
 		LogError("Invalid id: %s", sValue);
 	}
 	iSelTagId[client] = id;
-	
+
 }
 
 public Action RankMe_OnPlayerLoaded(int client)
@@ -497,10 +497,10 @@ public Action RankMe_LoadTags(int client, int rank, any data)
 		Debug_Print("Callback valid rank %L - %i", client, rank);
 		char sRank[16];
 		IntToString(iRank[client], sRank, sizeof(sRank));
-		
+
 		if (selectedTags[client].ScoreTag[0] == '\0')
 			return;
-			
+
 		ReplaceString(selectedTags[client].ScoreTag, sizeof(CustomTags::ScoreTag), "{rmRank}", sRank);
 		CS_SetClientClanTag(client, selectedTags[client].ScoreTag); //Instantly load the score-tag
 	}
@@ -510,7 +510,7 @@ public void Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
 {
 	if (!cv_bParseRoundEnd.BoolValue)
 	return;
-	
+
 	for (int i = 1; i <= MaxClients; i++)if (IsClientInGame(i))OnClientPostAdminCheck(i);
 }
 
@@ -521,7 +521,7 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 	{
 		return Plugin_Continue;
 	}
-	
+
 	Action result = Plugin_Continue;
 	//Call the forward
 	Call_StartForward(fMessagePreProcess);
@@ -529,21 +529,21 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 	Call_PushStringEx(name, MAXLENGTH_NAME, SM_PARAM_STRING_UTF8|SM_PARAM_STRING_COPY, SM_PARAM_COPYBACK);
 	Call_PushStringEx(message, MAXLENGTH_MESSAGE, SM_PARAM_STRING_UTF8|SM_PARAM_STRING_COPY, SM_PARAM_COPYBACK);
 	Call_Finish(result);
-	
+
 	if (result >= Plugin_Handled)
 	{
 		return Plugin_Continue;
 	}
-	
+
 	//Add colors & tags
 	char sNewName[MAXLENGTH_NAME];
 	char sNewMessage[MAXLENGTH_MESSAGE];
 	// Rainbow name
-	if (StrEqual(selectedTags[author].NameColor, "{rainbow}")) 
+	if (StrEqual(selectedTags[author].NameColor, "{rainbow}"))
 	{
 		Debug_Print("Rainbow name");
-		char sTemp[MAXLENGTH_MESSAGE]; 
-		
+		char sTemp[MAXLENGTH_MESSAGE];
+
 		int color;
 		int len = strlen(name);
 		for(int i = 0; i < len; i++)
@@ -553,21 +553,21 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 				Format(sTemp, sizeof(sTemp), "%s%c", sTemp, name[i]);
 				continue;
 			}
-			
+
 			int bytes = GetCharBytes(name[i])+1;
 			char[] c = new char[bytes];
 			strcopy(c, bytes, name[i]);
 			Format(sTemp, sizeof(sTemp), "%s%c%s", sTemp, GetColor(++color), c);
 			if (IsCharMB(name[i]))
 			i += bytes-2;
-		}		
+		}
 		Format(sNewName, MAXLENGTH_NAME, "%s%s{default}", selectedTags[author].ChatTag, sTemp);
 	}
 	else if (StrEqual(selectedTags[author].NameColor, "{random}")) //Random name
 	{
 		Debug_Print("Random name");
-		char sTemp[MAXLENGTH_MESSAGE]; 
-		
+		char sTemp[MAXLENGTH_MESSAGE];
+
 		int len = strlen(name);
 		for(int i = 0; i < len; i++)
 		{
@@ -576,14 +576,14 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 				Format(sTemp, sizeof(sTemp), "%s%c", sTemp, name[i]);
 				continue;
 			}
-			
+
 			int bytes = GetCharBytes(name[i])+1;
 			char[] c = new char[bytes];
 			strcopy(c, bytes, name[i]);
 			Format(sTemp, sizeof(sTemp), "%s%c%s", sTemp, GetRandomColor(), c);
 			if (IsCharMB(name[i]))
 			i += bytes-2;
-		}		
+		}
 		Format(sNewName, MAXLENGTH_NAME, "%s%s{default}", selectedTags[author].ChatTag, sTemp);
 	}
 	else
@@ -592,31 +592,31 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 		Format(sNewName, MAXLENGTH_NAME, "%s%s%s{default}", selectedTags[author].ChatTag, selectedTags[author].NameColor, name);
 	}
 	Format(sNewMessage, MAXLENGTH_MESSAGE, "%s%s", selectedTags[author].ChatColor, message);
-	
+
 	//Update the params
 	static char sTime[16];
-	FormatTime(sTime, sizeof(sTime), "%H:%M");  
+	FormatTime(sTime, sizeof(sTime), "%H:%M");
 	ReplaceString(sNewName, sizeof(sNewName), "{time}", sTime);
 	ReplaceString(sNewMessage, sizeof(sNewMessage), "{time}", sTime);
-	
-	
+
+
 	static char sIP[32];
 	static char sCountry[3];
 	GetClientIP(author, sIP, sizeof(sIP));
 	GeoipCode2(sIP, sCountry);
 	ReplaceString(sNewName, sizeof(sNewName), "{country}", sCountry);
 	ReplaceString(sNewMessage, sizeof(sNewMessage), "{country}", sCountry);
-	
+
 	if (bGangs)
 	{
 		Debug_Print("Apply gans");
 		static char sGang[32];
 		Gangs_HasGang(author) ?  Gangs_GetGangName(author, sGang, sizeof(sGang)) : cv_sDefaultGang.GetString(sGang, sizeof(sGang));
-		
+
 		ReplaceString(sNewName, sizeof(sNewName), "{gang}", sGang);
 		ReplaceString(sNewMessage, sizeof(sNewMessage), "{gang}", sGang);
 	}
-	
+
 	if (bRankme)
 	{
 		Debug_Print("Apply rankme");
@@ -624,20 +624,20 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 		IntToString(RankMe_GetPoints(author), sPoints, sizeof(sPoints));
 		ReplaceString(sNewName, sizeof(sNewName), "{rmPoints}", sPoints);
 		ReplaceString(sNewMessage, sizeof(sNewMessage), "{rmPoints}", sPoints);
-		
+
 		static char sRank[16];
 		IntToString(iRank[author], sRank, sizeof(sRank));
 		ReplaceString(sNewName, sizeof(sNewName), "{rmRank}", sRank);
 		ReplaceString(sNewMessage, sizeof(sNewMessage), "{rmRank}", sRank);
 	}
-	
+
 	//Rainbow Chat
 	if (StrEqual(selectedTags[author].ChatColor, "{rainbow}", false))
 	{
 		Debug_Print("Rainbow chat");
 		ReplaceString(sNewMessage, sizeof(sNewMessage), "{rainbow}", "");
-		char sTemp[MAXLENGTH_MESSAGE]; 
-		
+		char sTemp[MAXLENGTH_MESSAGE];
+
 		int color;
 		int len = strlen(sNewMessage);
 		for(int i = 0; i < len; i++)
@@ -647,24 +647,24 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 				Format(sTemp, sizeof(sTemp), "%s%c", sTemp, sNewMessage[i]);
 				continue;
 			}
-			
+
 			int bytes = GetCharBytes(sNewMessage[i])+1;
 			char[] c = new char[bytes];
 			strcopy(c, bytes, sNewMessage[i]);
 			Format(sTemp, sizeof(sTemp), "%s%c%s", sTemp, GetColor(++color), c);
 			if (IsCharMB(sNewMessage[i]))
 			i += bytes-2;
-		}		
-		Format(sNewMessage, MAXLENGTH_MESSAGE, "%s", sTemp); 
+		}
+		Format(sNewMessage, MAXLENGTH_MESSAGE, "%s", sTemp);
 	}
-	
+
 	//Random Chat
 	if (StrEqual(selectedTags[author].ChatColor, "{random}", false))
 	{
 		Debug_Print("Random chat");
 		ReplaceString(sNewMessage, sizeof(sNewMessage), "{random}", "");
-		char sTemp[MAXLENGTH_MESSAGE]; 
-		
+		char sTemp[MAXLENGTH_MESSAGE];
+
 		int len = strlen(sNewMessage);
 		for(int i = 0; i < len; i++)
 		{
@@ -673,23 +673,23 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 				Format(sTemp, sizeof(sTemp), "%s%c", sTemp, sNewMessage[i]);
 				continue;
 			}
-			
+
 			int bytes = GetCharBytes(sNewMessage[i])+1;
 			char[] c = new char[bytes];
 			strcopy(c, bytes, sNewMessage[i]);
 			Format(sTemp, sizeof(sTemp), "%s%c%s", sTemp, GetRandomColor(), c);
 			if (IsCharMB(sNewMessage[i]))
 			i += bytes-2;
-		}		
-		Format(sNewMessage, MAXLENGTH_MESSAGE, "%s", sTemp); 
+		}
+		Format(sNewMessage, MAXLENGTH_MESSAGE, "%s", sTemp);
 	}
-	
+
 	static char sPassedName[MAXLENGTH_NAME];
 	static char sPassedMessage[MAXLENGTH_NAME];
 	sPassedName = sNewName;
 	sPassedMessage = sNewMessage;
-	
-	
+
+
 	result = Plugin_Continue;
 	//Call the forward
 	Call_StartForward(fMessageProcess);
@@ -715,18 +715,18 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 		Debug_Setup();
 		return Plugin_Continue;
 	}
-	
+
 	processcolors = true;
 	removecolors = false;
-	
+
 	//Call the (post)forward
 	Call_StartForward(fMessageProcessed);
 	Call_PushCell(author);
 	Call_PushString(sPassedName);
 	Call_PushString(sPassedMessage);
 	Call_Finish();
-	
-	
+
+
 	Debug_Print("Message sent");
 	Debug_Setup();
 	return Plugin_Changed;
@@ -737,18 +737,18 @@ void LoadKv()
 {
 	static char sConfig[PLATFORM_MAX_PATH];
 	BuildPath(Path_SM, sConfig, sizeof(sConfig), "configs/hextags.cfg"); //Get cfg file
-	
+
 	if (OpenFile(sConfig, "rt") == null)
 		SetFailState("Couldn't find: \"%s\"", sConfig); //Check if cfg exist
-	
+
 	KeyValues kv = new KeyValues("HexTags"); //Create the kv
-	
+
 	if (!kv.ImportFromFile(sConfig))
 		SetFailState("Couldn't import: \"%s\"", sConfig); //Check if file was imported properly
-	
+
 	if (!kv.GotoFirstSubKey())
 		LogMessage("No entries found in: \"%s\"", sConfig); //Notify that there aren't any entries
-	
+
 	delete kv;
 	strcopy(sTagConf, sizeof(sTagConf), sConfig);
 	delete tagsKv;
@@ -758,13 +758,13 @@ void LoadTags(int client)
 {
 	if (bHideTag[client])
 		return;
-	
+
 	if (!IsValidClient(client, true, true))
 		return;
-	
+
 	//Clear the tags when re-checking
 	ResetTags(client);
-	
+
 	if (tagsKv == null)
 	{
 		tagsKv = new KeyValues("HexTags");
@@ -777,7 +777,7 @@ void LoadTags(int client)
 		userTags[client] = new ArrayList(sizeof(CustomTags));
 	}
 	ParseConfig(tagsKv, client);
-	
+
 	if (userTags[client].Length > 0)
 	{
 		if (iSelTagId[client] == 0 || !cv_bEnableTagsList.BoolValue)
@@ -795,7 +795,7 @@ void LoadTags(int client)
 		// Key found
 		int len = userTags[client].Length;
 		CustomTags tags;
-		
+
 		for (int i = 0; i < len; i++)
 		{
 			userTags[client].GetArray(i, tags, sizeof(CustomTags));
@@ -804,7 +804,7 @@ void LoadTags(int client)
 				selectedTags[client] = tags;
 				if (selectedTags[client].ScoreTag[0] == '\0')
 					return;
-					
+
 				CS_SetClientClanTag(client, selectedTags[client].ScoreTag);
 				return;
 			}
@@ -822,8 +822,8 @@ void ParseConfig(KeyValues kv, int client)
 		{
 			kv.GetSectionName(sSectionName, sizeof(sSectionName));
 			Debug_Print("Current key: %s", sSectionName);
-			
-			if (CheckSelector(sSectionName, client)) 
+
+			if (CheckSelector(sSectionName, client))
 			{
 				Debug_Print("*******FOUND VALID SELECTOR -> %s.", sSectionName);
 				ParseConfig(kv, client);
@@ -832,14 +832,14 @@ void ParseConfig(KeyValues kv, int client)
 		else
 		{
 			kv.GetSectionName(sSectionName, sizeof(sSectionName));
-			if (!CheckSelector(sSectionName, client)) 
+			if (!CheckSelector(sSectionName, client))
 			{
 				continue;
 			}
 			Debug_Print("***********SETTINGS TAGS", sSectionName);
 			GetTags(client, kv);
 		}
-	} while (kv.GotoNextKey());	
+	} while (kv.GotoNextKey());
 	Debug_Print("-- Section end --");
 }
 
@@ -850,28 +850,28 @@ bool CheckSelector(const char[] selector, int client)
 	{
 		return true;
 	}
-	
+
 	/* CHECK STEAMID */
 	if(strlen(selector) > 11 && StrContains(selector, "STEAM_", true) == 0)
 	{
 		char steamid[32];
 		if (!GetClientAuthId(client, AuthId_Steam2, steamid, sizeof(steamid)))
 			return false;
-		
-		if (StrEqual(steamid, selector)) 
+
+		if (StrEqual(steamid, selector))
 		{
 			return true;
 		}
-		
+
 			//Replace the STEAM_1 to STEAM_0 or viceversa
 		(steamid[6] == '1') ? (steamid[6] = '0') : (steamid[6] = '1');
-		if (StrEqual(steamid, selector)) 
+		if (StrEqual(steamid, selector))
 		{
 			return true;
 		}
 	}
-	
-	
+
+
 	/* PERMISSIONS RELATED CHECKS */
 	AdminId admin = GetUserAdmin(client);
 	if (admin != INVALID_ADMIN_ID)
@@ -880,7 +880,7 @@ bool CheckSelector(const char[] selector, int client)
 		if (selector[0] == '@')
 		{
 			static char sGroup[32];
-			
+
 			GroupId group = admin.GetGroup(0, sGroup, sizeof(sGroup));
 			if (group != INVALID_GROUP_ID)
 			{
@@ -890,7 +890,7 @@ bool CheckSelector(const char[] selector, int client)
 				}
 			}
 		}
-		
+
 		/* CHECK ADMIN FLAGS (1)*/
 		if (strlen(selector) == 1)
 		{
@@ -903,7 +903,7 @@ bool CheckSelector(const char[] selector, int client)
 				}
 			}
 		}
-		
+
 		/* CHECK ADMIN FLAGS (2)*/
 		if (selector[0] == '&')
 		{
@@ -920,39 +920,39 @@ bool CheckSelector(const char[] selector, int client)
 			}
 		}
 	}
-	
+
 	/* CHECK PLAYER TEAM */
 	int team = GetClientTeam(client);
 	static char sTeam[32];
-	
+
 	GetTeamName(team, sTeam, sizeof(sTeam));
 	if (StrEqual(sTeam, selector))
 	{
 		return true;
 	}
-	
+
 	/* CHECK TIME */
 	if (bMostActive && selector[0] == '#')
-	{	
+	{
 		int iPlayTime = MostActive_GetPlayTimeTotal(client);
 		if (iPlayTime >= StringToInt(selector[1]))
 		{
 			return true;
 		}
 	}
-	
+
 	/* CHECK WARDEN */
 	if (bWarden && StrEqual(selector, "warden", false) && warden_iswarden(client))
 	{
 		return true;
 	}
-	
+
 	/* CHECK DEPUTY */
 	if (bMyJBWarden && StrEqual(selector, "deputy", false) && warden_deputy_isdeputy(client))
 	{
 		return true;
 	}
-	
+
 	/* CHECK PRIME */
 	if (bSteamWorks && StrEqual(selector, "NoPrime", false))
 	{
@@ -961,13 +961,13 @@ bool CheckSelector(const char[] selector, int client)
 			return true;
 		}
 	}
-	
+
 	/* CHECK GANG */
 	if (bGangs && StrEqual(selector, "Gang", false) && Gangs_HasGang(client))
 	{
 		return true;
 	}
-	
+
 	/* CHECK RANKME */
 	if (bRankme && selector[0] == '!')
 	{
@@ -977,7 +977,7 @@ bool CheckSelector(const char[] selector, int client)
 			return true;
 		}
 	}
-	
+
 	/* CHECK STEAM GROUP */
 	if (bSteamWorks && selector[0] == '$')
 	{
@@ -986,31 +986,36 @@ bool CheckSelector(const char[] selector, int client)
 			return true;
 		}
 	}
-	
+
 
 	bool res = false;
-	
+
 	Call_StartForward(pfCustomSelector);
 	Call_PushCell(client);
 	Call_PushString(selector);
 	Call_Finish(res);
-	
+
 	return res;
+}
+
+bool IsFreezeTime()
+{
+	return(GameRules_GetProp("m_bFreezePeriod") == 1);
 }
 
 //Timers
 public Action Timer_ForceTag(Handle timer)
 {
 	if (!bCSGO)
-	return;
-	
+	return Plugin_Continue;
+
 	for (int i = 1; i <= MaxClients; i++)if (IsClientInGame(i) && selectedTags[i].ForceTag && selectedTags[i].ScoreTag[0] != '\0' && !bHideTag[i])
 	{
 		char sTag[32];
 		CS_GetClientClanTag(i, sTag, sizeof(sTag));
-		if (StrEqual(sTag, selectedTags[i].ScoreTag))
-		continue;
-		
+		if (StrEqual(sTag, selectedTags[i].ScoreTag) && !IsFreezeTime())
+		return Plugin_Continue;
+
 		LogMessage("%L was changed by an external plugin, forcing him back to the HexTags' default one!", i, sTag);
 		CS_SetClientClanTag(i, selectedTags[i].ScoreTag);
 	}
@@ -1028,7 +1033,7 @@ void GetTags(int client, KeyValues kv)
 	static char sSection[64];
 	static char sDef[8];
 	IntToString(iNextDefTag++, sDef, sizeof(sDef));
-	
+
 	kv.GetSectionName(sSection, sizeof(sSection));
 	Debug_Print("Section: %s", sSection);
 	int id;
@@ -1036,9 +1041,9 @@ void GetTags(int client, KeyValues kv)
 	{
 		LogError("Unable to get section symbol.");
 	}
-	
+
 	CustomTags tags;
-	
+
 	tags.SectionId = id;
 	kv.GetString("TagName", tags.TagName, sizeof(CustomTags::TagName), sDef);
 	kv.GetString("ScoreTag", tags.ScoreTag, sizeof(CustomTags::ScoreTag), "");
@@ -1047,11 +1052,11 @@ void GetTags(int client, KeyValues kv)
 	kv.GetString("NameColor", tags.NameColor, sizeof(CustomTags::NameColor), "{teamcolor}");
 	tags.ForceTag = kv.GetNum("ForceTag", 1) == 1;
 
-	
+
 	Call_StartForward(fTagsUpdated);
 	Call_PushCell(client);
 	Call_Finish();
-	
+
 	if (tags.ScoreTag[0] != '\0' && bCSGO)
 	{
 		//Update params
@@ -1081,16 +1086,16 @@ void GetTags(int client, KeyValues kv)
 			Debug_Print("Contains rmRank");
 			RankMe_GetRank(client, RankMe_LoadTags);
 		}
-		
+
 		Debug_Print("Setted tag: %s", tags.ScoreTag);
 		CS_SetClientClanTag(client, tags.ScoreTag); //Instantly load the score-tag
 	}
-	if (StrContains(tags.ChatTag, "{rainbow}") == 0) 
+	if (StrContains(tags.ChatTag, "{rainbow}") == 0)
 	{
 		Debug_Print("Found {rainbow} in ChatTag");
 		ReplaceString(tags.ChatTag, sizeof(CustomTags::ChatTag), "{rainbow}", "");
-		char sTemp[MAXLENGTH_MESSAGE]; 
-		
+		char sTemp[MAXLENGTH_MESSAGE];
+
 		int color;
 		int len = strlen(tags.ChatTag);
 		for(int i = 0; i < len; i++)
@@ -1100,7 +1105,7 @@ void GetTags(int client, KeyValues kv)
 				Format(sTemp, sizeof(sTemp), "%s%c", sTemp, tags.ChatTag[i]);
 				continue;
 			}
-			
+
 			int bytes = GetCharBytes(tags.ChatTag[i])+1;
 			char[] c = new char[bytes];
 			strcopy(c, bytes, tags.ChatTag[i]);
@@ -1111,7 +1116,7 @@ void GetTags(int client, KeyValues kv)
 		strcopy(tags.ChatTag, sizeof(CustomTags::ChatTag), sTemp);
 		Debug_Print("Replaced ChatTag with %s", tags.ChatTag);
 	}
-	if (StrContains(tags.ChatTag, "{random}") == 0) 
+	if (StrContains(tags.ChatTag, "{random}") == 0)
 	{
 		ReplaceString(tags.ChatTag, sizeof(CustomTags::ChatTag), "{random}", "");
 		char sTemp[MAXLENGTH_MESSAGE];
@@ -1123,7 +1128,7 @@ void GetTags(int client, KeyValues kv)
 				Format(sTemp, sizeof(sTemp), "%s%c", sTemp, tags.ChatTag[i]);
 				continue;
 			}
-			
+
 			int bytes = GetCharBytes(tags.ChatTag[i])+1;
 			char[] c = new char[bytes];
 			strcopy(c, bytes, tags.ChatTag[i]);
@@ -1175,7 +1180,7 @@ int GetColor(int color)
 	// TODO: Use modulo operator.
 	while(color > 7)
 	color -= 7;
-	
+
 	switch(color)
 	{
 		case  1: return '\x02';
@@ -1193,7 +1198,7 @@ int GetColor(int color)
 public int Native_GetClientTag(Handle plugin, int numParams)
 {
 	int client = GetNativeCell(1);
-	
+
 	if (client < 1 || client > MaxClients)
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index (%d)", client);
@@ -1202,23 +1207,23 @@ public int Native_GetClientTag(Handle plugin, int numParams)
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not connected", client);
 	}
-	
+
 	eTags tag = view_as<eTags>(GetNativeCell(2));
 	switch (tag)
 	{
-		case (ScoreTag): 
+		case (ScoreTag):
 		{
 			SetNativeString(3, selectedTags[client].ScoreTag, GetNativeCell(4));
 		}
-		case (ChatTag): 
+		case (ChatTag):
 		{
 			SetNativeString(3, selectedTags[client].ChatTag, GetNativeCell(4));
 		}
-		case (ChatColor): 
+		case (ChatColor):
 		{
 			SetNativeString(3, selectedTags[client].ChatColor, GetNativeCell(4));
 		}
-		case (NameColor): 
+		case (NameColor):
 		{
 			SetNativeString(3, selectedTags[client].NameColor, GetNativeCell(4));
 		}
@@ -1229,7 +1234,7 @@ public int Native_GetClientTag(Handle plugin, int numParams)
 public int Native_SetClientTag(Handle plugin, int numParams)
 {
 	int client = GetNativeCell(1);
-	
+
 	if (client < 1 || client > MaxClients)
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index (%d)", client);
@@ -1238,36 +1243,36 @@ public int Native_SetClientTag(Handle plugin, int numParams)
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not connected", client);
 	}
-	
+
 	char sTag[64];
 	eTags tag = view_as<eTags>(GetNativeCell(2));
-	
+
 	GetNativeString(3, sTag, sizeof(sTag));
 	ReplaceString(sTag, sizeof(sTag), "{darkgray}", "{gray2}");
-	
+
 	switch (tag)
 	{
-		case (ScoreTag): 
+		case (ScoreTag):
 		{
 			strcopy(selectedTags[client].ScoreTag, sizeof(CustomTags::ScoreTag), sTag);
 		}
-		case (ChatTag): 
+		case (ChatTag):
 		{
 			strcopy(selectedTags[client].ChatTag, sizeof(CustomTags::ChatTag), sTag);
 		}
-		case (ChatColor): 
+		case (ChatColor):
 		{
 			strcopy(selectedTags[client].ChatColor, sizeof(CustomTags::ChatColor), sTag);
 		}
-		case (NameColor): 
+		case (NameColor):
 		{
 			strcopy(selectedTags[client].NameColor, sizeof(CustomTags::NameColor), sTag);
 		}
 	}
-	
-	
+
+
 	Debug_Print("Called Native_SetClientTag(%i, %i, %s)", client, tag, sTag);
-	
+
 //	strcopy(selectedTags[client][Tag], sizeof(sTags[][]), sTag);
 	return 0;
 }
@@ -1275,7 +1280,7 @@ public int Native_SetClientTag(Handle plugin, int numParams)
 public int Native_ResetClientTags(Handle plugin, int numParams)
 {
 	int client = GetNativeCell(1);
-	
+
 	if (client < 1 || client > MaxClients)
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index (%d)", client);
@@ -1284,7 +1289,7 @@ public int Native_ResetClientTags(Handle plugin, int numParams)
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not connected", client);
 	}
-	
+
 	LoadTags(client);
 	return 0;
 }


### PR DESCRIPTION
Fixed console spamming when using RankMe, as the timer would fire during the freezetime after a round ends, thus checking if the client has a correct nametag, while it was changing.
Changes are on line 1001 to 1022, don't know why github glitches like that...