### PR TITLE
Fixed console spamming with Kento_RankMe

### DIFF
--- a/addons/sourcemod/scripting/hextags.sp
+++ b/addons/sourcemod/scripting/hextags.sp
@@ -70,6 +70,7 @@ bool bMyJBWarden;
 bool bGangs;
 bool bSteamWorks = true;
 bool bHideTag[MAXPLAYERS+1];
+bool bHasRoundEnded;
 
 int iRank[MAXPLAYERS+1] = {-1, ...};
 int iNextDefTag;
@@ -141,6 +142,7 @@ public void OnPluginStart()
 	//Event hooks
 	if (!HookEventEx("round_end", Event_RoundEnd))
 	LogError("Failed to hook \"round_end\", \"sm_hextags_roundend\" won't produce any effect.");
+	HookEvent("round_start", Event_RoundStart);
 	
 	hVibilityCookie = RegClientCookie("HexTags_Visibility", "Show or hide the tags.", CookieAccess_Private);
 	hSelTagCookie = RegClientCookie("HexTags_SelectedTag", "Selected Tag", CookieAccess_Private);
@@ -508,10 +510,16 @@ public Action RankMe_LoadTags(int client, int rank, any data)
 
 public void Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
 {
+	bHasRoundEnded = true;
 	if (!cv_bParseRoundEnd.BoolValue)
 	return;
-	
+
 	for (int i = 1; i <= MaxClients; i++)if (IsClientInGame(i))OnClientPostAdminCheck(i);
+}
+
+public void Event_RoundStart(Event event, const char[] name, bool dontBroadcast)
+{
+	bHasRoundEnded = false;
 }
 
 public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstring, char[] name, char[] message, bool& processcolors, bool& removecolors)
@@ -1011,7 +1019,10 @@ public Action Timer_ForceTag(Handle timer)
 		if (StrEqual(sTag, selectedTags[i].ScoreTag))
 		continue;
 		
-		LogMessage("%L was changed by an external plugin, forcing him back to the HexTags' default one!", i, sTag);
+		if (!bHasRoundEnded){
+			LogMessage("%L was changed by an external plugin, forcing him back to the HexTags' default one!", i, sTag);
+		}
+		
 		CS_SetClientClanTag(i, selectedTags[i].ScoreTag);
 	}
 }


### PR DESCRIPTION
When using Kento_RankMe and setting the cvar to change tags every rounds, the console would be spammed with the following message:
[hextags.smx] Player_Name was changed by an external plugin, forcing him back to the HexTags' default one!

This should fix this issue.