### PR TITLE
Changed the way tags are checked

### DIFF
--- a/addons/sourcemod/scripting/hextags.sp
+++ b/addons/sourcemod/scripting/hextags.sp
@@ -2,7 +2,7 @@
  * HexTags Plugin.
  * by: Hexah
  * https://github.com/Hexer10/HexTags
- * 
+ *
  * Copyright (C) 2017-2020 Mattia (Hexah|Hexer10|Papero)
  *
  * This file is part of the HexTags SourceMod Plugin.
@@ -10,7 +10,7 @@
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, version 3.0, as published by the
  * Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
@@ -56,6 +56,7 @@ Handle fMessageProcessed;
 Handle fMessagePreProcess;
 Handle hVibilityCookie;
 Handle hSelTagCookie;
+Handle g_RoundStatusTimer;
 
 ConVar cv_sDefaultGang;
 ConVar cv_bParseRoundEnd;
@@ -99,24 +100,24 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 {
 	//API
 	RegPluginLibrary("hextags");
-	
+
 	CreateNative("HexTags_GetClientTag", Native_GetClientTag);
 	CreateNative("HexTags_SetClientTag", Native_SetClientTag);
 	CreateNative("HexTags_ResetClientTag", Native_ResetClientTags);
 	CreateNative("HexTags_AddCustomSelector", Native_AddCustomSelector);
 	CreateNative("HexTags_RemoveCustomSelector", Native_RemoveCustomSelector);
-	
+
 	fTagsUpdated = new GlobalForward("HexTags_OnTagsUpdated", ET_Ignore, Param_Cell);
-	
+
 	fMessageProcess = new GlobalForward("HexTags_OnMessageProcess", ET_Single, Param_Cell, Param_String, Param_String);
 	fMessageProcessed = new GlobalForward("HexTags_OnMessageProcessed", ET_Ignore, Param_Cell, Param_String, Param_String);
 	fMessagePreProcess = new GlobalForward("HexTags_OnMessagePreProcess", ET_Single, Param_Cell, Param_String, Param_String);
-	
+
 	pfCustomSelector = new PrivateForward(ET_Single, Param_Cell, Param_String);
-	
+
 	EngineVersion engine = GetEngineVersion();
 	bCSGO = (engine == Engine_CSGO || engine == Engine_CSS);
-	
+
 	//LateLoad
 	bLate = late;
 	return APLRes_Success;
@@ -130,23 +131,23 @@ public void OnPluginStart()
 	cv_sDefaultGang = CreateConVar("sm_hextags_nogang", "", "Text to use if user has no tag - needs hl_gangs.");
 	cv_bParseRoundEnd = CreateConVar("sm_hextags_roundend", "0", "If 1 the tags will be reloaded even on round end - Suggested to be used with plugins like mostactive or rankme.");
 	cv_bEnableTagsList = CreateConVar("sm_hextags_enable_tagslist", "0", "Set to 1 to enable the sm_tagslist command.");
-	
+
 	AutoExecConfig();
-	
+
 	//Reg Cmds
 	RegAdminCmd("sm_reloadtags", Cmd_ReloadTags, ADMFLAG_GENERIC, "Reload HexTags plugin config");
 	RegAdminCmd("sm_toggletags", Cmd_ToggleTags, ADMFLAG_GENERIC, "Toggle the visibility of your tags");
 	RegConsoleCmd("sm_tagslist", Cmd_TagsList, "Select your tag!");
 	RegConsoleCmd("sm_getteam", Cmd_GetTeam, "Get current team name");
-	
+
 	//Event hooks
 	if (!HookEventEx("round_end", Event_RoundEnd))
 	LogError("Failed to hook \"round_end\", \"sm_hextags_roundend\" won't produce any effect.");
 	HookEvent("round_start", Event_RoundStart);
-	
+
 	hVibilityCookie = RegClientCookie("HexTags_Visibility", "Show or hide the tags.", CookieAccess_Private);
 	hSelTagCookie = RegClientCookie("HexTags_SelectedTag", "Selected Tag", CookieAccess_Private);
-	
+
 #if defined DEBUG
 	RegConsoleCmd("sm_gettagvars", Cmd_GetVars);
 	RegConsoleCmd("sm_firesel", Cmd_FireSel);
@@ -154,29 +155,29 @@ public void OnPluginStart()
 }
 
 public void OnAllPluginsLoaded()
-{	
+{
 	Debug_Print("Called OnAllPlugins!");
-	
+
 	if (FindPluginByFile("custom-chatcolors-cp.smx") || LibraryExists("ccc"))
 	LogMessage("[HexTags] Found Custom Chat Colors running!\n	Please avoid running it with this plugin!");
-	
+
 	bMostActive = LibraryExists("mostactive");
 	bRankme = LibraryExists("rankme");
 	bWarden = LibraryExists("warden");
 	bMyJBWarden = LibraryExists("myjbwarden");
 	bGangs = LibraryExists("hl_gangs");
 	bSteamWorks = LibraryExists("SteamWorks");
-	
+
 	LoadKv();
-	if (bLate) for (int i = 1; i <= MaxClients; i++)if (IsClientInGame(i)) 
+	if (bLate) for (int i = 1; i <= MaxClients; i++)if (IsClientInGame(i))
 	{
 		OnClientPutInServer(i);
 		if (!AreClientCookiesCached(i))
 			OnClientCookiesCached(i);
-		
+
 		OnClientPostAdminCheck(i);
 	}
-	
+
 	//Timers
 	if (bCSGO)
 	CreateTimer(5.0, Timer_ForceTag, _, TIMER_REPEAT);
@@ -251,32 +252,32 @@ public Action OnClientCommandKeyValues(int client, KeyValues kv)
 {
 	if (bHideTag[client])
 	return Plugin_Continue;
-	
+
 	char sKey[64];
-	
+
 	if (!bCSGO || !kv.GetSectionName(sKey, sizeof(sKey)))
 	return Plugin_Continue;
-	
+
 #if defined DEBUG
 	char sKV[256];
 	kv.ExportToString(sKV, sizeof(sKV));
 	Debug_Print("Called ClientCmdKv: %s\n%s\n", sKey, sKV);
 #endif
-	
+
 	if(StrEqual(sKey, "ClanTagChanged"))
 	{
 		kv.GetString("tag", sUserTag[client], sizeof(sUserTag[]));
 		LoadTags(client);
-		
+
 		if(selectedTags[client].ScoreTag[0] == '\0')
 		return Plugin_Continue;
-		
+
 		kv.SetString("tag", selectedTags[client].ScoreTag);
 		Debug_Print("[ClanTagChanged] Setted tag: %s ", selectedTags[client].ScoreTag);
 		return Plugin_Changed;
 	}
-	
-	return Plugin_Continue; 
+
+	return Plugin_Continue;
 }
 
 public void OnClientDisconnect(int client)
@@ -297,9 +298,9 @@ public void warden_OnWardenRemoved(int client)
 {
 	if (bCSGO)
 	CS_SetClientClanTag(client, sUserTag[client]);
-	
+
 	RequestFrame(Frame_LoadTag, client);
-	
+
 }
 
 public void warden_OnDeputyCreated(int client)
@@ -311,7 +312,7 @@ public void warden_OnDeputyRemoved(int client)
 {
 	if (bCSGO)
 	CS_SetClientClanTag(client, sUserTag[client]);
-	
+
 	RequestFrame(Frame_LoadTag, client);
 }
 
@@ -320,7 +321,7 @@ public Action Cmd_ReloadTags(int client, int args)
 {
 	LoadKv();
 	for (int i = 1; i <= MaxClients; i++)if (IsClientInGame(i))LoadTags(i);
-	
+
 	ReplyToCommand(client, "[SM] Tags succesfully reloaded!");
 	return Plugin_Handled;
 }
@@ -332,14 +333,14 @@ public Action Cmd_ToggleTags(int client, int args)
 		bHideTag[client] = false;
 		LoadTags(client);
 		ReplyToCommand(client, "[SM] Your tags are visible again.");
-	} 
+	}
 	else
 	{
 		bHideTag[client] = true;
 		CS_SetClientClanTag(client, sUserTag[client]);
 		ReplyToCommand(client, "[SM] Your tags are no longer visible.");
 	}
-	
+
 	SetClientCookie(client, hVibilityCookie, bHideTag[client] ? "0" : "1");
 }
 
@@ -350,25 +351,25 @@ public Action Cmd_TagsList(int client, int args)
 		ReplyToCommand(client, "[SM] In-game only command.");
 		return Plugin_Handled;
 	}
-	
+
 	if (userTags[client] == null)
 	{
 		ReplyToCommand(client, "[SM] Tags not yet loaded.");
 		return Plugin_Handled;
 	}
-	
-	if (!cv_bEnableTagsList.BoolValue) 
+
+	if (!cv_bEnableTagsList.BoolValue)
 	{
 		ReplyToCommand(client, "[SM] This feature is not enabled.");
 		return Plugin_Handled;
 	}
-	
+
 	if (userTags[client].Length == 0)
 	{
 		ReplyToCommand(client, "[SM] No tags available.");
 		return Plugin_Handled;
 	}
-	
+
 	Menu menu = new Menu(Handler_TagsMenu);
 	menu.SetTitle("Choose your tag:");
 	static char sIndex[16];
@@ -400,13 +401,13 @@ public int Handler_TagsMenu(Menu menu, MenuAction action, int param1, int param2
 			CS_SetClientClanTag(param1, selectedTags[param1].ScoreTag);
 		}
 		iSelTagId[param1] = selectedTags[param1].SectionId;
-		
+
 		static char sValue[32];
 		IntToString(iSelTagId[param1], sValue, sizeof(sValue));
 		SetClientCookie(param1, hSelTagCookie, sValue);
 		PrintToChat(param1, "[SM] Setted %s tags", selectedTags[param1].TagName);
 	}
-	
+
 }
 
 public Action Cmd_GetTeam(int client, int args)
@@ -416,7 +417,7 @@ public Action Cmd_GetTeam(int client, int args)
 		ReplyToCommand(client, "[SM] In-game only command.");
 		return Plugin_Handled;
 	}
-	
+
 	char sTeam[32];
 	GetTeamName(GetClientTeam(client), sTeam, sizeof(sTeam));
 	ReplyToCommand(client, "[SM] Current team name: %s", sTeam);
@@ -437,7 +438,7 @@ public Action Cmd_FireSel(int client, int args)
 {
 	int count = pfCustomSelector.FunctionCount;
 	int res;
-	
+
 	Call_StartForward(pfCustomSelector);
 	Call_PushCell(client);
 	Call_PushString("thistoggle");
@@ -463,9 +464,9 @@ public void OnClientCookiesCached(int client)
 {
 	static char sValue[32];
 	GetClientCookie(client, hVibilityCookie, sValue, sizeof(sValue));
-	
+
 	bHideTag[client] = sValue[0] == '\0' ? false : !StringToInt(sValue);
-		
+
 	GetClientCookie(client, hSelTagCookie, sValue, sizeof(sValue));
 	if (sValue[0] == '\0')
 	{
@@ -477,7 +478,7 @@ public void OnClientCookiesCached(int client)
 		LogError("Invalid id: %s", sValue);
 	}
 	iSelTagId[client] = id;
-	
+
 }
 
 public Action RankMe_OnPlayerLoaded(int client)
@@ -499,10 +500,10 @@ public Action RankMe_LoadTags(int client, int rank, any data)
 		Debug_Print("Callback valid rank %L - %i", client, rank);
 		char sRank[16];
 		IntToString(iRank[client], sRank, sizeof(sRank));
-		
+
 		if (selectedTags[client].ScoreTag[0] == '\0')
 			return;
-			
+
 		ReplaceString(selectedTags[client].ScoreTag, sizeof(CustomTags::ScoreTag), "{rmRank}", sRank);
 		CS_SetClientClanTag(client, selectedTags[client].ScoreTag); //Instantly load the score-tag
 	}
@@ -519,7 +520,19 @@ public void Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
 
 public void Event_RoundStart(Event event, const char[] name, bool dontBroadcast)
 {
-	bHasRoundEnded = false;
+	delete g_RoundStatusTimer;
+	g_RoundStatusTimer = CreateTimer(5.0, ChangeRoundStatus);
+}
+
+public Action ChangeRoundStatus(Handle timer)
+{
+		bHasRoundEnded = false;
+		g_RoundStatusTimer = null;
+}
+
+public void OnMapEnd() // required, because forcible change level doesn't fire "round_end" event
+{
+    delete g_RoundStatusTimer;
 }
 
 public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstring, char[] name, char[] message, bool& processcolors, bool& removecolors)
@@ -529,7 +542,7 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 	{
 		return Plugin_Continue;
 	}
-	
+
 	Action result = Plugin_Continue;
 	//Call the forward
 	Call_StartForward(fMessagePreProcess);
@@ -537,21 +550,21 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 	Call_PushStringEx(name, MAXLENGTH_NAME, SM_PARAM_STRING_UTF8|SM_PARAM_STRING_COPY, SM_PARAM_COPYBACK);
 	Call_PushStringEx(message, MAXLENGTH_MESSAGE, SM_PARAM_STRING_UTF8|SM_PARAM_STRING_COPY, SM_PARAM_COPYBACK);
 	Call_Finish(result);
-	
+
 	if (result >= Plugin_Handled)
 	{
 		return Plugin_Continue;
 	}
-	
+
 	//Add colors & tags
 	char sNewName[MAXLENGTH_NAME];
 	char sNewMessage[MAXLENGTH_MESSAGE];
 	// Rainbow name
-	if (StrEqual(selectedTags[author].NameColor, "{rainbow}")) 
+	if (StrEqual(selectedTags[author].NameColor, "{rainbow}"))
 	{
 		Debug_Print("Rainbow name");
-		char sTemp[MAXLENGTH_MESSAGE]; 
-		
+		char sTemp[MAXLENGTH_MESSAGE];
+
 		int color;
 		int len = strlen(name);
 		for(int i = 0; i < len; i++)
@@ -561,21 +574,21 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 				Format(sTemp, sizeof(sTemp), "%s%c", sTemp, name[i]);
 				continue;
 			}
-			
+
 			int bytes = GetCharBytes(name[i])+1;
 			char[] c = new char[bytes];
 			strcopy(c, bytes, name[i]);
 			Format(sTemp, sizeof(sTemp), "%s%c%s", sTemp, GetColor(++color), c);
 			if (IsCharMB(name[i]))
 			i += bytes-2;
-		}		
+		}
 		Format(sNewName, MAXLENGTH_NAME, "%s%s{default}", selectedTags[author].ChatTag, sTemp);
 	}
 	else if (StrEqual(selectedTags[author].NameColor, "{random}")) //Random name
 	{
 		Debug_Print("Random name");
-		char sTemp[MAXLENGTH_MESSAGE]; 
-		
+		char sTemp[MAXLENGTH_MESSAGE];
+
 		int len = strlen(name);
 		for(int i = 0; i < len; i++)
 		{
@@ -584,14 +597,14 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 				Format(sTemp, sizeof(sTemp), "%s%c", sTemp, name[i]);
 				continue;
 			}
-			
+
 			int bytes = GetCharBytes(name[i])+1;
 			char[] c = new char[bytes];
 			strcopy(c, bytes, name[i]);
 			Format(sTemp, sizeof(sTemp), "%s%c%s", sTemp, GetRandomColor(), c);
 			if (IsCharMB(name[i]))
 			i += bytes-2;
-		}		
+		}
 		Format(sNewName, MAXLENGTH_NAME, "%s%s{default}", selectedTags[author].ChatTag, sTemp);
 	}
 	else
@@ -600,31 +613,31 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 		Format(sNewName, MAXLENGTH_NAME, "%s%s%s{default}", selectedTags[author].ChatTag, selectedTags[author].NameColor, name);
 	}
 	Format(sNewMessage, MAXLENGTH_MESSAGE, "%s%s", selectedTags[author].ChatColor, message);
-	
+
 	//Update the params
 	static char sTime[16];
-	FormatTime(sTime, sizeof(sTime), "%H:%M");  
+	FormatTime(sTime, sizeof(sTime), "%H:%M");
 	ReplaceString(sNewName, sizeof(sNewName), "{time}", sTime);
 	ReplaceString(sNewMessage, sizeof(sNewMessage), "{time}", sTime);
-	
-	
+
+
 	static char sIP[32];
 	static char sCountry[3];
 	GetClientIP(author, sIP, sizeof(sIP));
 	GeoipCode2(sIP, sCountry);
 	ReplaceString(sNewName, sizeof(sNewName), "{country}", sCountry);
 	ReplaceString(sNewMessage, sizeof(sNewMessage), "{country}", sCountry);
-	
+
 	if (bGangs)
 	{
 		Debug_Print("Apply gans");
 		static char sGang[32];
 		Gangs_HasGang(author) ?  Gangs_GetGangName(author, sGang, sizeof(sGang)) : cv_sDefaultGang.GetString(sGang, sizeof(sGang));
-		
+
 		ReplaceString(sNewName, sizeof(sNewName), "{gang}", sGang);
 		ReplaceString(sNewMessage, sizeof(sNewMessage), "{gang}", sGang);
 	}
-	
+
 	if (bRankme)
 	{
 		Debug_Print("Apply rankme");
@@ -632,20 +645,20 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 		IntToString(RankMe_GetPoints(author), sPoints, sizeof(sPoints));
 		ReplaceString(sNewName, sizeof(sNewName), "{rmPoints}", sPoints);
 		ReplaceString(sNewMessage, sizeof(sNewMessage), "{rmPoints}", sPoints);
-		
+
 		static char sRank[16];
 		IntToString(iRank[author], sRank, sizeof(sRank));
 		ReplaceString(sNewName, sizeof(sNewName), "{rmRank}", sRank);
 		ReplaceString(sNewMessage, sizeof(sNewMessage), "{rmRank}", sRank);
 	}
-	
+
 	//Rainbow Chat
 	if (StrEqual(selectedTags[author].ChatColor, "{rainbow}", false))
 	{
 		Debug_Print("Rainbow chat");
 		ReplaceString(sNewMessage, sizeof(sNewMessage), "{rainbow}", "");
-		char sTemp[MAXLENGTH_MESSAGE]; 
-		
+		char sTemp[MAXLENGTH_MESSAGE];
+
 		int color;
 		int len = strlen(sNewMessage);
 		for(int i = 0; i < len; i++)
@@ -655,24 +668,24 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 				Format(sTemp, sizeof(sTemp), "%s%c", sTemp, sNewMessage[i]);
 				continue;
 			}
-			
+
 			int bytes = GetCharBytes(sNewMessage[i])+1;
 			char[] c = new char[bytes];
 			strcopy(c, bytes, sNewMessage[i]);
 			Format(sTemp, sizeof(sTemp), "%s%c%s", sTemp, GetColor(++color), c);
 			if (IsCharMB(sNewMessage[i]))
 			i += bytes-2;
-		}		
-		Format(sNewMessage, MAXLENGTH_MESSAGE, "%s", sTemp); 
+		}
+		Format(sNewMessage, MAXLENGTH_MESSAGE, "%s", sTemp);
 	}
-	
+
 	//Random Chat
 	if (StrEqual(selectedTags[author].ChatColor, "{random}", false))
 	{
 		Debug_Print("Random chat");
 		ReplaceString(sNewMessage, sizeof(sNewMessage), "{random}", "");
-		char sTemp[MAXLENGTH_MESSAGE]; 
-		
+		char sTemp[MAXLENGTH_MESSAGE];
+
 		int len = strlen(sNewMessage);
 		for(int i = 0; i < len; i++)
 		{
@@ -681,23 +694,23 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 				Format(sTemp, sizeof(sTemp), "%s%c", sTemp, sNewMessage[i]);
 				continue;
 			}
-			
+
 			int bytes = GetCharBytes(sNewMessage[i])+1;
 			char[] c = new char[bytes];
 			strcopy(c, bytes, sNewMessage[i]);
 			Format(sTemp, sizeof(sTemp), "%s%c%s", sTemp, GetRandomColor(), c);
 			if (IsCharMB(sNewMessage[i]))
 			i += bytes-2;
-		}		
-		Format(sNewMessage, MAXLENGTH_MESSAGE, "%s", sTemp); 
+		}
+		Format(sNewMessage, MAXLENGTH_MESSAGE, "%s", sTemp);
 	}
-	
+
 	static char sPassedName[MAXLENGTH_NAME];
 	static char sPassedMessage[MAXLENGTH_NAME];
 	sPassedName = sNewName;
 	sPassedMessage = sNewMessage;
-	
-	
+
+
 	result = Plugin_Continue;
 	//Call the forward
 	Call_StartForward(fMessageProcess);
@@ -723,18 +736,18 @@ public Action CP_OnChatMessage(int& author, ArrayList recipients, char[] flagstr
 		Debug_Setup();
 		return Plugin_Continue;
 	}
-	
+
 	processcolors = true;
 	removecolors = false;
-	
+
 	//Call the (post)forward
 	Call_StartForward(fMessageProcessed);
 	Call_PushCell(author);
 	Call_PushString(sPassedName);
 	Call_PushString(sPassedMessage);
 	Call_Finish();
-	
-	
+
+
 	Debug_Print("Message sent");
 	Debug_Setup();
 	return Plugin_Changed;
@@ -745,18 +758,18 @@ void LoadKv()
 {
 	static char sConfig[PLATFORM_MAX_PATH];
 	BuildPath(Path_SM, sConfig, sizeof(sConfig), "configs/hextags.cfg"); //Get cfg file
-	
+
 	if (OpenFile(sConfig, "rt") == null)
 		SetFailState("Couldn't find: \"%s\"", sConfig); //Check if cfg exist
-	
+
 	KeyValues kv = new KeyValues("HexTags"); //Create the kv
-	
+
 	if (!kv.ImportFromFile(sConfig))
 		SetFailState("Couldn't import: \"%s\"", sConfig); //Check if file was imported properly
-	
+
 	if (!kv.GotoFirstSubKey())
 		LogMessage("No entries found in: \"%s\"", sConfig); //Notify that there aren't any entries
-	
+
 	delete kv;
 	strcopy(sTagConf, sizeof(sTagConf), sConfig);
 	delete tagsKv;
@@ -766,13 +779,13 @@ void LoadTags(int client)
 {
 	if (bHideTag[client])
 		return;
-	
+
 	if (!IsValidClient(client, true, true))
 		return;
-	
+
 	//Clear the tags when re-checking
 	ResetTags(client);
-	
+
 	if (tagsKv == null)
 	{
 		tagsKv = new KeyValues("HexTags");
@@ -785,7 +798,7 @@ void LoadTags(int client)
 		userTags[client] = new ArrayList(sizeof(CustomTags));
 	}
 	ParseConfig(tagsKv, client);
-	
+
 	if (userTags[client].Length > 0)
 	{
 		if (iSelTagId[client] == 0 || !cv_bEnableTagsList.BoolValue)
@@ -803,7 +816,7 @@ void LoadTags(int client)
 		// Key found
 		int len = userTags[client].Length;
 		CustomTags tags;
-		
+
 		for (int i = 0; i < len; i++)
 		{
 			userTags[client].GetArray(i, tags, sizeof(CustomTags));
@@ -812,7 +825,7 @@ void LoadTags(int client)
 				selectedTags[client] = tags;
 				if (selectedTags[client].ScoreTag[0] == '\0')
 					return;
-					
+
 				CS_SetClientClanTag(client, selectedTags[client].ScoreTag);
 				return;
 			}
@@ -830,8 +843,8 @@ void ParseConfig(KeyValues kv, int client)
 		{
 			kv.GetSectionName(sSectionName, sizeof(sSectionName));
 			Debug_Print("Current key: %s", sSectionName);
-			
-			if (CheckSelector(sSectionName, client)) 
+
+			if (CheckSelector(sSectionName, client))
 			{
 				Debug_Print("*******FOUND VALID SELECTOR -> %s.", sSectionName);
 				ParseConfig(kv, client);
@@ -840,14 +853,14 @@ void ParseConfig(KeyValues kv, int client)
 		else
 		{
 			kv.GetSectionName(sSectionName, sizeof(sSectionName));
-			if (!CheckSelector(sSectionName, client)) 
+			if (!CheckSelector(sSectionName, client))
 			{
 				continue;
 			}
 			Debug_Print("***********SETTINGS TAGS", sSectionName);
 			GetTags(client, kv);
 		}
-	} while (kv.GotoNextKey());	
+	} while (kv.GotoNextKey());
 	Debug_Print("-- Section end --");
 }
 
@@ -858,52 +871,52 @@ bool CheckSelector(const char[] selector, int client)
 	{
 		return true;
 	}
-	
+
 	/* CHECK HUMAN */
 	if (StrEqual(selector, "human", false) && !IsFakeClient(client))
 	{
 		return true;
 	}
-	
+
 	/* CHECK BOT */
 	if (StrEqual(selector, "bot", false) && IsFakeClient(client))
 	{
 		return true;
 	}
-	
+
 	/* CHECK STEAMID */
 	if(strlen(selector) > 11 && StrContains(selector, "STEAM_", true) == 0)
 	{
 		char steamid[32];
 		if (!GetClientAuthId(client, AuthId_Steam2, steamid, sizeof(steamid)))
 			return false;
-		
-		if (StrEqual(steamid, selector)) 
+
+		if (StrEqual(steamid, selector))
 		{
 			return true;
 		}
-		
+
 			//Replace the STEAM_1 to STEAM_0 or viceversa
 		(steamid[6] == '1') ? (steamid[6] = '0') : (steamid[6] = '1');
-		if (StrEqual(steamid, selector)) 
+		if (StrEqual(steamid, selector))
 		{
 			return true;
 		}
 	}
-	
-	
+
+
 	/* PERMISSIONS RELATED CHECKS */
 	AdminId admin = GetUserAdmin(client);
 	if (admin != INVALID_ADMIN_ID)
 	{
-		
+
 		Debug_Print("Found as admin! %N", client);
 		/* CHECK ADMIN GROUP */
 		if (selector[0] == '@')
 		{
 			Debug_Print("Check group: %s",selector);
 			static char sGroup[32];
-			
+
 			GroupId group = admin.GetGroup(0, sGroup, sizeof(sGroup));
 			if (group != INVALID_GROUP_ID)
 			{
@@ -913,7 +926,7 @@ bool CheckSelector(const char[] selector, int client)
 				}
 			}
 		}
-		
+
 		/* CHECK ADMIN FLAGS (1)*/
 		if (strlen(selector) == 1)
 		{
@@ -927,7 +940,7 @@ bool CheckSelector(const char[] selector, int client)
 				}
 			}
 		}
-		
+
 		/* CHECK ADMIN FLAGS (2)*/
 		if (selector[0] == '&')
 		{
@@ -946,39 +959,39 @@ bool CheckSelector(const char[] selector, int client)
 		}
 		Debug_Print("Unmatched admin: %s", selector);
 	}
-	
+
 	/* CHECK PLAYER TEAM */
 	int team = GetClientTeam(client);
 	static char sTeam[32];
-	
+
 	GetTeamName(team, sTeam, sizeof(sTeam));
 	if (StrEqual(sTeam, selector))
 	{
 		return true;
 	}
-	
+
 	/* CHECK TIME */
 	if (bMostActive && selector[0] == '#')
-	{	
+	{
 		int iPlayTime = MostActive_GetPlayTimeTotal(client);
 		if (iPlayTime >= StringToInt(selector[1]))
 		{
 			return true;
 		}
 	}
-	
+
 	/* CHECK WARDEN */
 	if (bWarden && StrEqual(selector, "warden", false) && warden_iswarden(client))
 	{
 		return true;
 	}
-	
+
 	/* CHECK DEPUTY */
 	if (bMyJBWarden && StrEqual(selector, "deputy", false) && warden_deputy_isdeputy(client))
 	{
 		return true;
 	}
-	
+
 	/* CHECK PRIME */
 	if (bSteamWorks && StrEqual(selector, "NoPrime", false))
 	{
@@ -987,13 +1000,13 @@ bool CheckSelector(const char[] selector, int client)
 			return true;
 		}
 	}
-	
+
 	/* CHECK GANG */
 	if (bGangs && StrEqual(selector, "Gang", false) && Gangs_HasGang(client))
 	{
 		return true;
 	}
-	
+
 	/* CHECK RANKME */
 	if (bRankme && selector[0] == '!')
 	{
@@ -1003,7 +1016,7 @@ bool CheckSelector(const char[] selector, int client)
 			return true;
 		}
 	}
-	
+
 	/* CHECK STEAM GROUP */
 	if (bSteamWorks && selector[0] == '$')
 	{
@@ -1012,15 +1025,15 @@ bool CheckSelector(const char[] selector, int client)
 			return true;
 		}
 	}
-	
+
 
 	bool res = false;
-	
+
 	Call_StartForward(pfCustomSelector);
 	Call_PushCell(client);
 	Call_PushString(selector);
 	Call_Finish(res);
-	
+
 	return res;
 }
 
@@ -1029,18 +1042,18 @@ public Action Timer_ForceTag(Handle timer)
 {
 	if (!bCSGO)
 	return;
-	
+
 	for (int i = 1; i <= MaxClients; i++)if (IsClientInGame(i) && selectedTags[i].ForceTag && selectedTags[i].ScoreTag[0] != '\0' && !bHideTag[i])
 	{
 		char sTag[32];
 		CS_GetClientClanTag(i, sTag, sizeof(sTag));
 		if (StrEqual(sTag, selectedTags[i].ScoreTag))
 		continue;
-		
+
 		if (!bHasRoundEnded){
 			LogMessage("%L was changed by an external plugin, forcing him back to the HexTags' default one!", i, sTag);
 		}
-		
+
 		CS_SetClientClanTag(i, selectedTags[i].ScoreTag);
 	}
 }
@@ -1057,7 +1070,7 @@ void GetTags(int client, KeyValues kv)
 	static char sSection[64];
 	static char sDef[8];
 	IntToString(iNextDefTag++, sDef, sizeof(sDef));
-	
+
 	kv.GetSectionName(sSection, sizeof(sSection));
 	Debug_Print("Section: %s", sSection);
 	int id;
@@ -1065,9 +1078,9 @@ void GetTags(int client, KeyValues kv)
 	{
 		LogError("Unable to get section symbol.");
 	}
-	
+
 	CustomTags tags;
-	
+
 	tags.SectionId = id;
 	kv.GetString("TagName", tags.TagName, sizeof(CustomTags::TagName), sDef);
 	kv.GetString("ScoreTag", tags.ScoreTag, sizeof(CustomTags::ScoreTag), "");
@@ -1076,11 +1089,11 @@ void GetTags(int client, KeyValues kv)
 	kv.GetString("NameColor", tags.NameColor, sizeof(CustomTags::NameColor), "{teamcolor}");
 	tags.ForceTag = kv.GetNum("ForceTag", 1) == 1;
 
-	
+
 	Call_StartForward(fTagsUpdated);
 	Call_PushCell(client);
 	Call_Finish();
-	
+
 	if (tags.ScoreTag[0] != '\0' && bCSGO)
 	{
 		//Update params
@@ -1110,16 +1123,16 @@ void GetTags(int client, KeyValues kv)
 			Debug_Print("Contains rmRank");
 			RankMe_GetRank(client, RankMe_LoadTags);
 		}
-		
+
 		Debug_Print("Setted tag: %s", tags.ScoreTag);
 		CS_SetClientClanTag(client, tags.ScoreTag); //Instantly load the score-tag
 	}
-	if (StrContains(tags.ChatTag, "{rainbow}") == 0) 
+	if (StrContains(tags.ChatTag, "{rainbow}") == 0)
 	{
 		Debug_Print("Found {rainbow} in ChatTag");
 		ReplaceString(tags.ChatTag, sizeof(CustomTags::ChatTag), "{rainbow}", "");
-		char sTemp[MAXLENGTH_MESSAGE]; 
-		
+		char sTemp[MAXLENGTH_MESSAGE];
+
 		int color;
 		int len = strlen(tags.ChatTag);
 		for(int i = 0; i < len; i++)
@@ -1129,7 +1142,7 @@ void GetTags(int client, KeyValues kv)
 				Format(sTemp, sizeof(sTemp), "%s%c", sTemp, tags.ChatTag[i]);
 				continue;
 			}
-			
+
 			int bytes = GetCharBytes(tags.ChatTag[i])+1;
 			char[] c = new char[bytes];
 			strcopy(c, bytes, tags.ChatTag[i]);
@@ -1140,7 +1153,7 @@ void GetTags(int client, KeyValues kv)
 		strcopy(tags.ChatTag, sizeof(CustomTags::ChatTag), sTemp);
 		Debug_Print("Replaced ChatTag with %s", tags.ChatTag);
 	}
-	if (StrContains(tags.ChatTag, "{random}") == 0) 
+	if (StrContains(tags.ChatTag, "{random}") == 0)
 	{
 		ReplaceString(tags.ChatTag, sizeof(CustomTags::ChatTag), "{random}", "");
 		char sTemp[MAXLENGTH_MESSAGE];
@@ -1152,7 +1165,7 @@ void GetTags(int client, KeyValues kv)
 				Format(sTemp, sizeof(sTemp), "%s%c", sTemp, tags.ChatTag[i]);
 				continue;
 			}
-			
+
 			int bytes = GetCharBytes(tags.ChatTag[i])+1;
 			char[] c = new char[bytes];
 			strcopy(c, bytes, tags.ChatTag[i]);
@@ -1204,7 +1217,7 @@ int GetColor(int color)
 	// TODO: Use modulo operator.
 	while(color > 7)
 	color -= 7;
-	
+
 	switch(color)
 	{
 		case  1: return '\x02';
@@ -1222,7 +1235,7 @@ int GetColor(int color)
 public int Native_GetClientTag(Handle plugin, int numParams)
 {
 	int client = GetNativeCell(1);
-	
+
 	if (client < 1 || client > MaxClients)
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index (%d)", client);
@@ -1231,23 +1244,23 @@ public int Native_GetClientTag(Handle plugin, int numParams)
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not connected", client);
 	}
-	
+
 	eTags tag = view_as<eTags>(GetNativeCell(2));
 	switch (tag)
 	{
-		case (ScoreTag): 
+		case (ScoreTag):
 		{
 			SetNativeString(3, selectedTags[client].ScoreTag, GetNativeCell(4));
 		}
-		case (ChatTag): 
+		case (ChatTag):
 		{
 			SetNativeString(3, selectedTags[client].ChatTag, GetNativeCell(4));
 		}
-		case (ChatColor): 
+		case (ChatColor):
 		{
 			SetNativeString(3, selectedTags[client].ChatColor, GetNativeCell(4));
 		}
-		case (NameColor): 
+		case (NameColor):
 		{
 			SetNativeString(3, selectedTags[client].NameColor, GetNativeCell(4));
 		}
@@ -1258,7 +1271,7 @@ public int Native_GetClientTag(Handle plugin, int numParams)
 public int Native_SetClientTag(Handle plugin, int numParams)
 {
 	int client = GetNativeCell(1);
-	
+
 	if (client < 1 || client > MaxClients)
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index (%d)", client);
@@ -1267,36 +1280,36 @@ public int Native_SetClientTag(Handle plugin, int numParams)
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not connected", client);
 	}
-	
+
 	char sTag[64];
 	eTags tag = view_as<eTags>(GetNativeCell(2));
-	
+
 	GetNativeString(3, sTag, sizeof(sTag));
 	ReplaceString(sTag, sizeof(sTag), "{darkgray}", "{gray2}");
-	
+
 	switch (tag)
 	{
-		case (ScoreTag): 
+		case (ScoreTag):
 		{
 			strcopy(selectedTags[client].ScoreTag, sizeof(CustomTags::ScoreTag), sTag);
 		}
-		case (ChatTag): 
+		case (ChatTag):
 		{
 			strcopy(selectedTags[client].ChatTag, sizeof(CustomTags::ChatTag), sTag);
 		}
-		case (ChatColor): 
+		case (ChatColor):
 		{
 			strcopy(selectedTags[client].ChatColor, sizeof(CustomTags::ChatColor), sTag);
 		}
-		case (NameColor): 
+		case (NameColor):
 		{
 			strcopy(selectedTags[client].NameColor, sizeof(CustomTags::NameColor), sTag);
 		}
 	}
-	
-	
+
+
 	Debug_Print("Called Native_SetClientTag(%i, %i, %s)", client, tag, sTag);
-	
+
 //	strcopy(selectedTags[client][Tag], sizeof(sTags[][]), sTag);
 	return 0;
 }
@@ -1304,7 +1317,7 @@ public int Native_SetClientTag(Handle plugin, int numParams)
 public int Native_ResetClientTags(Handle plugin, int numParams)
 {
 	int client = GetNativeCell(1);
-	
+
 	if (client < 1 || client > MaxClients)
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index (%d)", client);
@@ -1313,7 +1326,7 @@ public int Native_ResetClientTags(Handle plugin, int numParams)
 	{
 		return ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not connected", client);
 	}
-	
+
 	LoadTags(client);
 	return 0;
 }


### PR DESCRIPTION
Changed the way tags are checked when `cv_bParseRoundEnd ` is set to 1. Should completely fix the console spamming.

I've created a new bool which disables the message when the round has ended. A timer ensures that all tag checking is done before changing the bool to false.

**TESTED**